### PR TITLE
Use a lightweight JVM-specific docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM ubuntu:trusty
-ENV LC_ALL C
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN true
+FROM airdock/oracle-jdk:1.8
+
 ENV MB_JETTY_HOST 0.0.0.0
 ENV MB_JETTY_PORT 3000
 ENV DB_FILE_NAME /app/files/corvus


### PR DESCRIPTION
A little more lightweight; should speed up deployment times (maybe).

Either way the Oracle JDK 8 should have some performance advantages over OpenJDK 7 or whatever the old container runs
